### PR TITLE
fix Enable path-style access for MinIO S3 Bucket

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
           "iceberg.catalog.s3.endpoint": "http://minio:9000",
           "iceberg.catalog.s3.secret-access-key": "minioadmin",
           "iceberg.catalog.s3.access-key-id": "minioadmin",
+          "iceberg.catalog.s3.path-style-access": "true",
           "iceberg.catalog.uri": "http://rest:8181",
           "iceberg.catalog.warehouse": "s3://warehouse/",
           "iceberg.catalog.client.region": "eu-west-1",
@@ -180,6 +181,7 @@ services:
         spark.sql.catalog.iceberg.io-impl       org.apache.iceberg.aws.s3.S3FileIO
         spark.sql.catalog.iceberg.warehouse     s3://warehouse/wh/
         spark.sql.catalog.iceberg.s3.endpoint   http://minio:9000
+        spark.sql.catalog.iceberg.s3.path-style-access  true
         spark.sql.defaultCatalog                iceberg
         spark.sql.catalogImplementation         in-memory
         spark.eventLog.enabled                  true


### PR DESCRIPTION
Thank you for the fantastic demo!

While running in my environment, I encountered an error related to path-style access not being enabled. 

<details><summary>error log</summary>

```log
connect        | [2024-02-17 16:44:50,677] ERROR WorkerSinkTask{id=IcebergSinkConnector-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted. Error: null (Service: S3, Status Code: 503, Request ID: null) (org.apache.kafka.connect.runtime.WorkerSinkTask)
connect        | software.amazon.awssdk.services.s3.model.S3Exception: null (Service: S3, Status Code: 503, Request ID: null)
connect        |        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)
connect        |        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)
connect        |        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)
connect        |        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:43)
connect        |        at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:95)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$7(BaseClientHandler.java:270)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:72)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:52)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:37)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
connect        |        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56)
connect        |        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
connect        |        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
connect        |        at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:196)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:171)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:179)
connect        |        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)
connect        |        at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
connect        |        at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)
connect        |        at software.amazon.awssdk.services.s3.DefaultS3Client.putObject(DefaultS3Client.java:8783)
connect        |        at org.apache.iceberg.aws.s3.S3OutputStream.completeUploads(S3OutputStream.java:438)
connect        |        at org.apache.iceberg.aws.s3.S3OutputStream.close(S3OutputStream.java:265)
connect        |        at org.apache.parquet.io.DelegatingPositionOutputStream.close(DelegatingPositionOutputStream.java:38)
connect        |        at org.apache.parquet.hadoop.ParquetFileWriter.end(ParquetFileWriter.java:1204)
connect        |        at org.apache.iceberg.parquet.ParquetWriter.close(ParquetWriter.java:257)
connect        |        at org.apache.iceberg.io.DataWriter.close(DataWriter.java:82)
connect        |        at org.apache.iceberg.io.BaseTaskWriter$BaseRollingWriter.closeCurrent(BaseTaskWriter.java:314)
connect        |        at org.apache.iceberg.io.BaseTaskWriter$BaseRollingWriter.close(BaseTaskWriter.java:341)
connect        |        at org.apache.iceberg.io.PartitionedFanoutWriter.close(PartitionedFanoutWriter.java:70)
connect        |        at org.apache.iceberg.io.BaseTaskWriter.complete(BaseTaskWriter.java:96)
connect        |        at io.tabular.iceberg.connect.data.IcebergWriter.flush(IcebergWriter.java:130)
connect        |        at io.tabular.iceberg.connect.data.IcebergWriter.complete(IcebergWriter.java:145)
connect        |        at io.tabular.iceberg.connect.channel.Worker.lambda$receive$2(Worker.java:112)
connect        |        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
connect        |        at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1693)
connect        |        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
connect        |        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
connect        |        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
connect        |        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
connect        |        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
connect        |        at io.tabular.iceberg.connect.channel.Worker.receive(Worker.java:112)
connect        |        at io.tabular.iceberg.connect.channel.Channel.lambda$consumeAvailable$2(Channel.java:129)
connect        |        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
connect        |        at io.tabular.iceberg.connect.channel.Channel.consumeAvailable(Channel.java:119)
connect        |        at io.tabular.iceberg.connect.channel.Worker.process(Worker.java:101)
connect        |        at io.tabular.iceberg.connect.IcebergSinkTask.processControlEvents(IcebergSinkTask.java:165)
connect        |        at io.tabular.iceberg.connect.IcebergSinkTask.put(IcebergSinkTask.java:152)
connect        |        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:581)
connect        |        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:333)
connect        |        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:234)
connect        |        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:203)
connect        |        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:189)
connect        |        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:244)
connect        |        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
connect        |        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
connect        |        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
connect        |        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
connect        |        at java.base/java.lang.Thread.run(Thread.java:829)
connect        |        Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 1 failure: null (Service: S3, Status Code: 503, Request ID: null)
connect        |        Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 2 failure: null (Service: S3, Status Code: 503, Request ID: null)
connect        |        Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 3 failure: null (Service: S3, Status Code: 503, Request ID: null)

```

</details>


Here's the fix I applied to address this issue. Please feel free to use it if it fits your needs.


----

Additionally, while this PR does not include changes related to it, I have also verified that the current latest `tabular/iceberg-kafka-connect:0.6.5` operates correctly with these configurations. Just thought it might be useful for reference.

Further, if upgrading to v0.6.5, a change in parameter names requires the following adjustments as well.

```diff
-          "iceberg.control.commitIntervalMs": "1000",
+          "iceberg.control.commit.interval-ms": "1000",
```